### PR TITLE
Correct import instruction

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,4 +3,4 @@ Package gin implements a HTTP web framework called gin.
 
 See https://gin-gonic.github.io/gin/ for more information about gin.
 */
-package gin // import "github.com/gin-gonic/gin"
+package gin // import "github.com/teera123/gin"


### PR DESCRIPTION
The current code is forked from the original branch but the import instruction is still the same which cause compile failure when using with vendor on Go 1.13 and GO111MODULE=off:
`vendor\github.com\teera123\gin expects import "github.com/gin-gonic/gin"`
 A work around is set GO111MODULE=on.

This change propose a fix to correct the import instruction of the package to the current path of the repo.

